### PR TITLE
Make variable declaration and usage same

### DIFF
--- a/src/lib/content/cadence-by-example/en/4-variables.md
+++ b/src/lib/content/cadence-by-example/en/4-variables.md
@@ -17,15 +17,15 @@ pub contract Variables {
    pub let num2: Int
 
    init() {
-      self.number1 = 1
-      self.number1 = 2 // good
+      self.num1 = 1
+      self.num1 = 2 // good
 
-      self.number2 = 1
+      self.num2 = 1
 
       /*
        ERROR: not allowed
        
-       self.number2 = 2
+       self.numr2 = 2
       */
    }
 }


### PR DESCRIPTION
This fixes the inconsistency in initialization and usage in number variable